### PR TITLE
fixed issue with outbound tracking where inbound server resets were being dropped during tcp handshake   

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+# [0.5.6] - 2024-01-19
+
+###
+
+-- Fixed issue in outbound tracking for passthrough tcp connections where packets with rst set from
+   server were only accepted if connection was already in established state.  Changed to allow rst during
+   tcp handshake which occurs when server refuses a connection.
+
 # [0.5.5] - 2024-01-05
 
 ###

--- a/src/zfw.c
+++ b/src/zfw.c
@@ -152,7 +152,7 @@ char *tc_interface;
 char *log_file_name;
 char *object_file;
 char *direction_string;
-const char *argp_program_version = "0.5.5";
+const char *argp_program_version = "0.5.6";
 struct ring_buffer *ring_buffer;
 
 __u8 if_list[MAX_IF_LIST_ENTRIES];

--- a/src/zfw_tc_ingress.c
+++ b/src/zfw_tc_ingress.c
@@ -905,17 +905,15 @@ int bpf_sk_splice(struct __sk_buff *skb){
                     }
                 }
                 else if(tcph->rst){
-                    if(tstate->est){
-                        del_tcp(tcp_state_key);
-                        tstate = get_tcp(tcp_state_key);
-                        if(!tstate){
-                            if(local_diag->verbose){
-                                event.tracking_code = SERVER_RST_RCVD;
-                                send_event(&event);
-                            }
+                    del_tcp(tcp_state_key);
+                    tstate = get_tcp(tcp_state_key);
+                    if(!tstate){
+                        if(local_diag->verbose){
+                            event.tracking_code = SERVER_RST_RCVD;
+                            send_event(&event);
                         }
-                        return TC_ACT_OK;
                     }
+                    return TC_ACT_OK;
                 }
                 else if(tcph->ack){
                     if((tstate->est) && (tstate->sfin == 1) && (tstate->cfin == 1) && (bpf_htonl(tcph->ack_seq) == (bpf_htonl(tstate->cfseq) + 1))){


### PR DESCRIPTION
Fixed an issue where if a server responded with a reset during the tcp handshake the reset would be dropped for tcp sessions initiated from local trusted clients utilizing outbound tracking.   Resets are seen during handshake when the server refuses the connection.